### PR TITLE
Skip the error to make sure the task can stop 

### DIFF
--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -11,6 +11,7 @@ DIR_ARR=("core" "server")
 for i in "${DIR_ARR[@]}"
 do
     pushd "${ROOT_DIR}/${i}"
+    go mod tidy
     go test -race -coverprofile=coverage.out -covermode=atomic "./..." -v
     if [[ -f coverage.out ]]; then
         cat coverage.out >> "$COVER_OUT"

--- a/server/cdc_impl_test.go
+++ b/server/cdc_impl_test.go
@@ -228,7 +228,9 @@ func TestReload(t *testing.T) {
 
 		metaCDC.replicateEntityMap.Lock()
 		metaCDC.replicateEntityMap.data = map[string]*ReplicateEntity{
-			"127.0.0.1:19530": {},
+			"127.0.0.1:19530": {
+				quitFunc: func() {},
+			},
 		}
 		metaCDC.replicateEntityMap.Unlock()
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -118,6 +118,14 @@ var (
 			Help:      "the size of the message",
 		}, []string{taskIDLabelName, vchannelLabelName, opTypeName})
 
+	ReplicateDataCntVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: systemName,
+			Name:      "replicate_data_cnt",
+			Help:      "the data count",
+		}, []string{taskIDLabelName, collectionIDLabelName, collectionNameLabelName, opTypeName})
+
 	APIExecuteCountVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: milvusNamespace,
 		Subsystem: systemName,
@@ -134,6 +142,7 @@ func init() {
 	registry.MustRegister(TaskRequestCountVec)
 	registry.MustRegister(ReplicateTimeVec)
 	registry.MustRegister(ReplicateDataSizeVec)
+	registry.MustRegister(ReplicateDataCntVec)
 	registry.MustRegister(APIExecuteCountVec)
 	registry.MustRegister(reader.TSMetricVec)
 }


### PR DESCRIPTION
Skip the error to make sure the task can stop when failing to update the task position