### PR TITLE
use the smaller buffer size in the msg dispatcher

### DIFF
--- a/core/reader/etcd_op.go
+++ b/core/reader/etcd_op.go
@@ -568,7 +568,9 @@ func (e *EtcdOp) internalGetAllCollection(ctx context.Context, fillField bool, f
 		info := &pb.CollectionInfo{}
 		err = proto.Unmarshal(kv.Value, info)
 		if err != nil {
-			log.Info("fail to unmarshal collection info, maybe it's a deleted collection", zap.String("key", util.ToString(kv.Key)), zap.String("value", util.Base64Encode(kv.Value)), zap.Error(err))
+			if !util.IsTombstone(kv.Value) {
+				log.Info("fail to unmarshal collection info", zap.String("key", util.ToString(kv.Key)), zap.String("value", util.Base64Encode(kv.Value)), zap.Error(err))
+			}
 			continue
 		}
 		hasFilter := false

--- a/core/reader/replicate_channel_manager.go
+++ b/core/reader/replicate_channel_manager.go
@@ -788,6 +788,7 @@ func (r *replicateChannelHandler) AddCollection(sourceInfo *model.SourceCollecti
 	}()
 	r.recordLock.Unlock()
 	log.Info("add collection to channel handler",
+		zap.String("channel_name", sourceInfo.VChannelName),
 		zap.Int64("collection_id", collectionID), zap.String("collection_name", targetInfo.CollectionName))
 
 	if targetInfo.Dropped {

--- a/core/util/milvus_param.go
+++ b/core/util/milvus_param.go
@@ -29,5 +29,5 @@ func InitMilvusPkgParam() {
 	innerParam := paramtable.Get()
 	_ = innerParam.Save(innerParam.MQCfg.MaxTolerantLag.Key, "5")
 	_ = innerParam.Save(innerParam.MQCfg.MergeCheckInterval.Key, "2")
-	_ = innerParam.Save(innerParam.MQCfg.TargetBufSize.Key, "128")
+	_ = innerParam.Save(innerParam.MQCfg.TargetBufSize.Key, "16")
 }


### PR DESCRIPTION
In order to ensure that when the target milvus is abnormal, the chan of msg dispatch will be quickly filled up, causing the cdc service to be abnormal