### PR TITLE
fix: resolve connection error by security protocol

### DIFF
--- a/core/reader/factory_api.go
+++ b/core/reader/factory_api.go
@@ -89,7 +89,7 @@ func (d *DefaultFactoryCreator) NewKmsFactory(cfg *config.KafkaConfig) msgstream
 				SaslUsername:        config.NewParamItem(cfg.SaslUsername),
 				SaslPassword:        config.NewParamItem(cfg.SaslPassword),
 				SaslMechanisms:      config.NewParamItem(cfg.SaslMechanisms),
-				SecurityProtocol:    config.NewParamItem(cfg.SaslMechanisms),
+				SecurityProtocol:    config.NewParamItem(cfg.SecurityProtocol),
 				ConsumerExtraConfig: config.NewParamGroup(cfg.Consumer),
 				ProducerExtraConfig: config.NewParamGroup(cfg.Producer),
 				ReadTimeout:         config.NewParamItem("10"),


### PR DESCRIPTION
```
%4|1727246243.038|FAIL|rdkafka#consumer-1| [thrd:mykafka:9092/bootstrap: Disconnected: verify that security.protocol is correctly configured, broker might require SASL authentication (after 347ms in state UP, 7 identical error(s) suppressed)
```